### PR TITLE
Fix: Manejo de carga de imagen de perfil con loader y fallback

### DIFF
--- a/lib/view/navigation/app_drawer.dart
+++ b/lib/view/navigation/app_drawer.dart
@@ -233,10 +233,23 @@ class _AppDrawerState extends State<AppDrawer> {
                             // SE MUESTRA LA IMAGEN A TRAVES DEL URL GUARDADO
                             child: ClipOval(
                               child: Image.network(
-                                imageUrl,
+                                // SI LA URL ES NULA O VACIA, SE PASA UN STRING VACIO
+                                imageUrl ?? '',
                                 fit: BoxFit.cover,
                                 width: 140,
                                 height: 140,
+                                errorBuilder: (context, error, stackTrace) {
+                                  // SI FALLA LA CARGA DE IMAGEN, MOSTRAR ICONO DE PERFIL POR DEFECTO
+                                  return const Icon(Icons.person, size: 40);
+                                },
+                                loadingBuilder:
+                                    (context, child, loadingProgress) {
+                                  // MIENTRAS SE CARGA, MOSTRAR UN LOADER
+                                  if (loadingProgress == null) return child;
+                                  return const Center(
+                                    child: CircularProgressIndicator(),
+                                  );
+                                },
                               ),
                             )),
                   ),


### PR DESCRIPTION
Este PR soluciona el error visual momentáneo que aparecía al cargar la imagen de perfil del usuario desde Supabase en el Drawer o pantallas donde se muestra el `CircleAvatar`.

Ahora, en lugar de mostrar un error mientras la imagen se está cargando, se presenta un **loader** (`CircularProgressIndicator`). Si la imagen no se carga correctamente, se muestra un ícono por defecto (`Icons.person`).

---

### Implementación
Se actualizó el `Image.network` para manejar correctamente los estados de carga y error:

```dart
child: Image.network(
  imageUrl ?? '', // SI LA URL ES NULA O VACÍA, SE PASA UN STRING VACÍO
  fit: BoxFit.cover,
  width: 140,
  height: 140,
  errorBuilder: (context, error, stackTrace) {
    // SI FALLA LA CARGA DE IMAGEN, MOSTRAR ICONO DE PERFIL POR DEFECTO
    return Icon(Icons.person, size: 40);
  },
  loadingBuilder: (context, child, loadingProgress) {
    // MIENTRAS SE CARGA, MOSTRAR UN LOADER
    if (loadingProgress == null) return child;
    return Center(
      child: CircularProgressIndicator(),
    );
  },
),